### PR TITLE
chore: cherry pick lodash imports

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,5 +3,5 @@
     "react-app",
     "flow"
   ],
-  "plugins": ["inline-react-svg", "jsx-control-statements", "emotion", "babel-plugin-react-css-modules"]
+  "plugins": ["inline-react-svg", "jsx-control-statements", "emotion", "babel-plugin-react-css-modules", "lodash"]
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "babel-plugin-flow-react-proptypes": "^23.0.0",
     "babel-plugin-inline-react-svg": "^0.5.2",
     "babel-plugin-jsx-control-statements": "^3.2.8",
+    "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-react-css-modules": "3.4.0",
     "babel-preset-flow": "^6.23.0",
     "babel-preset-react-app": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,7 +17,7 @@
     "@babel/types" "7.0.0-beta.32"
     lodash "^4.2.0"
 
-"@babel/helper-module-imports@^7.0.0":
+"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.0.0-beta.49":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz#96081b7111e486da4d2cd971ad1a4fe216cc2e3d"
   integrity sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==
@@ -56,6 +56,15 @@
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.10"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.0.0-beta.49":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.5.5.tgz#97b9f728e182785909aa4ab56264f090a028d18a"
+  integrity sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
 "@emotion/babel-utils@^0.6.4":
@@ -1273,6 +1282,17 @@ babel-plugin-jsx-control-statements@^3.2.8:
   dependencies:
     babel-core "^6.1.2"
     babel-plugin-syntax-jsx "^6.1.18"
+
+babel-plugin-lodash@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-lodash/-/babel-plugin-lodash-3.3.4.tgz#4f6844358a1340baed182adbeffa8df9967bc196"
+  integrity sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0-beta.49"
+    "@babel/types" "^7.0.0-beta.49"
+    glob "^7.1.1"
+    lodash "^4.17.10"
+    require-package-name "^2.0.1"
 
 babel-plugin-macros@^2.0.0, babel-plugin-macros@^2.2.0:
   version "2.2.0"
@@ -9618,6 +9638,11 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
   integrity sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=
+
+require-package-name@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/require-package-name/-/require-package-name-2.0.1.tgz#c11e97276b65b8e2923f75dabf5fb2ef0c3841b9"
+  integrity sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk=
 
 require-uncached@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
Added https://github.com/lodash/babel-plugin-lodash in order to decrease bundle size

Before (CRA with @8base/boost):
![image](https://user-images.githubusercontent.com/10157660/62555781-3b307e00-b87c-11e9-8bfc-f1c7e221c10c.png)

After:
![image](https://user-images.githubusercontent.com/10157660/62555826-4d122100-b87c-11e9-999f-5c73fb3d34ee.png)
