### PR TITLE
chore(Input): should hide number input's spinner in mozilla

### DIFF
--- a/src/components/Input/Input.theme.js
+++ b/src/components/Input/Input.theme.js
@@ -29,6 +29,10 @@ const [InputTag, themeInput] = createThemeTag(name, ({ COLORS, SIZES }: *): * =>
       margin: 0,
     },
 
+    '&[type=number]': {
+      '-moz-appearance': 'textfield',
+    },
+
     '&::-ms-clear': {
       display: 'none',
     },


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/10157660/66765813-5ee3f600-eeb5-11e9-899a-a13c3b3f533b.png)

After:
![image](https://user-images.githubusercontent.com/10157660/66765846-6d321200-eeb5-11e9-90a5-6c8e261a7c20.png)
